### PR TITLE
TestCase.use_default_loop to reuse existing loop

### DIFF
--- a/asynctest/selector.py
+++ b/asynctest/selector.py
@@ -119,6 +119,8 @@ class SSLSocketMock(SocketMock):
     Mock a socket wrapped by the :mod:`ssl` module.
 
     See :class:`~asynctest.FileMock`.
+
+    .. versionadded:: 0.5
     """
     def __init__(self, side_effect=None, return_value=mock.DEFAULT,
                  wraps=None, name=None, spec_set=None, parent=None,


### PR DESCRIPTION
implements feature request in bug #1 

    class MyTestCase(asynctest.TestCase):
      use_default_loop = True
    
      def test_mytest(self):
          pass  # self.loop is asyncio.get_event_loop(), and won't be recycled.