### PR TITLE
Patch generators

### DIFF
--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -38,18 +38,18 @@ class FakeInheritanceMeta(type):
         new = type(cls.__name__, (cls, ), {'__doc__': cls.__doc__})
         return object.__new__(new)
 
-    def __instancecheck__(self, obj):
+    def __instancecheck__(cls, obj):
         # That's tricky, each type(mock) is actually a subclass of the actual
         # Mock type (see __new__)
         if super().__instancecheck__(obj):
             return True
 
         _type = type(obj)
-        if issubclass(self, NonCallableMock):
+        if issubclass(cls, NonCallableMock):
             if issubclass(_type, (NonCallableMagicMock, Mock, )):
                 return True
 
-        if issubclass(self, Mock) and not issubclass(self, CoroutineMock):
+        if issubclass(cls, Mock) and not issubclass(cls, CoroutineMock):
             if issubclass(_type, (MagicMock, )):
                 return True
 

--- a/test/test_mock_await.py
+++ b/test/test_mock_await.py
@@ -16,3 +16,15 @@ def transform(coro):
         return await coro(*a, **kw)
 
     return a_coroutine
+
+
+# make a simple coroutine which invokes a function before awaiting on an
+# awaitable and after
+def build_simple_coroutine(before_func, after_func=None):
+    async def a_coroutine(awaitable, *args, **kwargs):
+        before = before_func(*args, **kwargs)
+        await awaitable
+        after = (after_func or before_func)(*args, **kwargs)
+        return before, after
+
+    return a_coroutine


### PR DESCRIPTION
After #5, update on the way coroutines and generators are patched using asynctest.mock.patch as a function decorator.