### PR TITLE
Fail the test when there are active handles in the loop at the end

### DIFF
--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -173,15 +173,13 @@ class TestCase(unittest.case.TestCase):
         self.loop = self._patch_loop(self.loop)
 
     @staticmethod
-    def _scheduled_handle_alive(handle):
-        cancelled_timer_handle = (
-            isinstance(scheduled_thing, asyncio.TimerHandle) and
-            scheduled_thing._cancelled)
-        return not cancelled_timer_handle
+    def _is_live_timer_handle(handle):
+        return (
+            isinstance(handle, asyncio.TimerHandle) and not handle._cancelled)
 
     @property
-    def _live_handles(self):
-        return filter(self._scheduled_handle_alive, self.loop._scheduled)
+    def _live_timer_handles(self):
+        return filter(self._is_live_timer_handle, self.loop._scheduled)
 
     def _unset_loop(self):
         policy = asyncio.get_event_loop_policy()
@@ -326,7 +324,7 @@ class TestCase(unittest.case.TestCase):
             if not self.loop.__asynctest_ran:
                 self.fail("Loop did not run during the test")
         if fail_checks['active_handles']:
-            live_handles = tuple(self._live_handles)
+            live_handles = tuple(self._live_timer_handles)
             if live_handles:
                 self.fail('Loop contained unfinished work {}'.format(
                     live_handles))

--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -355,14 +355,6 @@ class FunctionTestCase(TestCase, unittest.FunctionTestCase):
     """
 
 
-def ignore_loop(test):
-    """
-    Ignore the error case where the loop did not run during the test.
-    """
-    test.__asynctest_ignore_loop__ = True
-    return test
-
-
 _FAIL_DEFAULTS = {
     'unused_loop': True,
     'active_handles': False

--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -322,15 +322,14 @@ class TestCase(unittest.case.TestCase):
         result = method()
         if asyncio.iscoroutine(result):
             self.loop.run_until_complete(result)
-        else:
-            if fail_checks['unused_loop']:
-                if not self.loop.__asynctest_ran:
-                    self.fail("Loop did not run during the test")
-            if fail_checks['active_handles']:
-                live_handles = tuple(self._live_handles)
-                if live_handles:
-                    self.fail('Loop contained unfinished work {}'.format(
-                        live_handles))
+        elif fail_checks['unused_loop']:
+            if not self.loop.__asynctest_ran:
+                self.fail("Loop did not run during the test")
+        if fail_checks['active_handles']:
+            live_handles = tuple(self._live_handles)
+            if live_handles:
+                self.fail('Loop contained unfinished work {}'.format(
+                    live_handles))
 
     def _get_fail_checks(self, method):
         checks = _FAIL_DEFAULTS.copy()

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -323,9 +323,9 @@ class Test_TestCase(_TestCase):
 
     def test_fails_when_future_has_scheduled_calls(self):
         class CruftyTest(asynctest.TestCase):
-            @asynctest.fail_on(active_handles=True)
-            def test_scheduling_without_wait(instance):
-                asyncio.sleep(10, loop=instance.loop)
+            @asynctest.fail_on(active_handles=True, unused_loop=False)
+            def runTest(instance):
+                instance.loop.call_later(5, lambda: None)
 
         with self.subTest(test=CruftyTest):
             with self.assertRaisesRegex(AssertionError, 'unfinished work'):

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -321,6 +321,18 @@ class Test_TestCase(_TestCase):
                 result = test().run()
                 self.assertEqual(0, len(result.failures))
 
+    def test_fails_when_future_has_scheduled_calls(self):
+        class CruftyTest(asynctest.TestCase):
+            @asynctest.fail_on(active_handles=True)
+            def test_scheduling_without_wait(instance):
+                asyncio.sleep(10, loop=instance.loop)
+
+        with self.subTest(test=CruftyTest):
+            with self.assertRaisesRegex(AssertionError, 'unfinished work'):
+                CruftyTest().debug()
+            result = CruftyTest().run()
+            self.assertEqual(1, len(result.failures))
+
     def test_setup_teardown_may_be_coroutines(self):
         @asynctest.ignore_loop
         class WithSetupFunction(Test.FooTestCase):

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -236,9 +236,10 @@ class Test_TestCase(_TestCase):
             def runTest(instance):
                 instance.loop.call_later(5, lambda: None)
 
-        with self.subTest(test=CruftyTest):
+        with self.subTest(method='debug'):
             with self.assertRaisesRegex(AssertionError, 'unfinished work'):
                 CruftyTest().debug()
+        with self.subTest(method='run'):
             result = CruftyTest().run()
             self.assertEqual(1, len(result.failures))
 


### PR DESCRIPTION
Just to make sure there are no outstanding timers (or half finished other things).

I found it helpful to keep tests self contained.

Will tidy and test further if you're interested. Just wondered what you make of such a thing.