### PR TITLE
Add test case with an advance() method to spool forward time

### DIFF
--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -343,7 +343,7 @@ class FunctionTestCase(TestCase, unittest.FunctionTestCase):
 class ClockedTestCase(TestCase):
     def setUp(self):
         super().setUp()
-        self.loop.time = lambda: self.time
+        self.loop.time = functools.wraps(self.loop.time)(lambda: self.time)
         self.time = 0
 
     def advance(self, seconds):

--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -343,20 +343,20 @@ class FunctionTestCase(TestCase, unittest.FunctionTestCase):
 class ClockedTestCase(TestCase):
     def setUp(self):
         super().setUp()
-        self.loop.time = functools.wraps(self.loop.time)(lambda: self.time)
-        self.time = 0
+        self.loop.time = functools.wraps(self.loop.time)(lambda: self._time)
+        self._time = 0
 
     def advance(self, seconds):
         if seconds < 0:
             raise ValueError(
                 'Cannot go back in time ({} seconds)'.format(seconds))
         self._drain_loop()
-        self.time += seconds
+        self._time += seconds
         self._drain_loop()
 
     def _drain_loop(self):
         while self.loop._ready or any(map(
-                lambda handle: handle._when <= self.time,
+                lambda handle: handle._when <= self._time,
                 self.loop._scheduled)):
             self.loop._run_once()
             self.loop._TestCase__asynctest_ran = True

--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -346,6 +346,7 @@ class ClockedTestCase(TestCase):
         self.loop.time = functools.wraps(self.loop.time)(lambda: self._time)
         self._time = 0
 
+    @asyncio.coroutine
     def advance(self, seconds):
         if seconds < 0:
             raise ValueError(
@@ -358,7 +359,7 @@ class ClockedTestCase(TestCase):
         while self.loop._ready or any(map(
                 lambda handle: handle._when <= self._time,
                 self.loop._scheduled)):
-            self.loop._run_once()
+            yield from asyncio.sleep(0)
             self.loop._TestCase__asynctest_ran = True
 
 

--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -341,6 +341,10 @@ class FunctionTestCase(TestCase, unittest.FunctionTestCase):
 
 
 class ClockedTestCase(TestCase):
+    '''Subclass of :class:`~asynctest.TestCase` with tester controlled time...
+
+    useful for testing timer based behaviour without slowing test run time.'''
+
     def setUp(self):
         super().setUp()
         self.loop.time = functools.wraps(self.loop.time)(lambda: self._time)
@@ -348,6 +352,7 @@ class ClockedTestCase(TestCase):
 
     @asyncio.coroutine
     def advance(self, seconds):
+        '''Fast forward time by a number of seconds'''
         if seconds < 0:
             raise ValueError(
                 'Cannot go back in time ({} seconds)'.format(seconds))

--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -347,7 +347,9 @@ class ClockedTestCase(TestCase):
         self.time = 0
 
     def advance(self, seconds):
-        assert seconds >= 0
+        if seconds < 0:
+            raise ValueError(
+                'Cannot go back in time ({} seconds)'.format(seconds))
         self._drain_loop()
         self.time += seconds
         self._drain_loop()

--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -340,6 +340,26 @@ class FunctionTestCase(TestCase, unittest.FunctionTestCase):
     """
 
 
+class ClockedTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.loop.time = lambda: self.time
+        self.time = 0
+
+    def advance(self, seconds):
+        assert seconds >= 0
+        self._drain_loop()
+        self.time += seconds
+        self._drain_loop()
+
+    def _drain_loop(self):
+        while self.loop._ready or any(map(
+                lambda handle: handle._when <= self.time,
+                self.loop._scheduled)):
+            self.loop._run_once()
+            self.loop._TestCase__asynctest_ran = True
+
+
 def ignore_loop(test):
     """
     Ignore the error case where the loop did not run during the test.

--- a/doc/asynctest.case.rst
+++ b/doc/asynctest.case.rst
@@ -4,8 +4,8 @@
        :maxdepth: 2
 
 
-    TestCase and FunctionTestCase
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    TestCases
+    ~~~~~~~~~
 
     .. autoclass:: asynctest.TestCase
         :members:
@@ -29,6 +29,10 @@
         :members:
         :undoc-members:
 
+    .. autoclass:: asynctest.ClockedTestCase
+        :members:
+        :undoc-members:
+        :exclude-members: setUp
 
     Decorators
     ~~~~~~~~~~

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -7,6 +7,7 @@ import unittest
 import unittest.mock
 import subprocess
 import sys
+import time
 
 import asynctest
 
@@ -444,6 +445,21 @@ class Test_TestCase_and_ChildWatcher(_TestCase):
                 coro = Test.StartWaitProcessTestCase.start_wait_process(
                     default_loop)
                 default_loop.run_until_complete(coro)
+
+
+class Test_ClockedTestCase(asynctest.ClockedTestCase):
+    def test_advance(self):
+        f = asyncio.Future(loop=self.loop)
+        started_wall_clock = time.monotonic()
+        started_loop_clock = self.loop.time()
+        self.loop.call_later(1, f.set_result, None)
+        self.advance(1)
+        self.loop.run_until_complete(f)
+        finished_wall_clock = time.monotonic()
+        finished_loop_clock = self.loop.time()
+        self.assertLess(
+            finished_wall_clock - started_wall_clock,
+            finished_loop_clock - started_loop_clock)
 
 
 if __name__ == "__main__":

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -448,13 +448,14 @@ class Test_TestCase_and_ChildWatcher(_TestCase):
 
 
 class Test_ClockedTestCase(asynctest.ClockedTestCase):
+    @asyncio.coroutine
     def test_advance(self):
         f = asyncio.Future(loop=self.loop)
         started_wall_clock = time.monotonic()
         started_loop_clock = self.loop.time()
         self.loop.call_later(1, f.set_result, None)
-        self.advance(1)
-        self.loop.run_until_complete(f)
+        yield from self.advance(1)
+        yield from f
         finished_wall_clock = time.monotonic()
         finished_loop_clock = self.loop.time()
         self.assertLess(

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -451,11 +451,17 @@ class Test_ClockedTestCase(asynctest.ClockedTestCase):
     @asyncio.coroutine
     def test_advance(self):
         f = asyncio.Future(loop=self.loop)
+        g = asyncio.Future(loop=self.loop)
         started_wall_clock = time.monotonic()
         started_loop_clock = self.loop.time()
         self.loop.call_later(1, f.set_result, None)
+        self.loop.call_later(2, g.set_result, None)
+        self.assertFalse(f.done())
         yield from self.advance(1)
         yield from f
+        self.assertFalse(g.done())
+        yield from self.advance(9)
+        yield from g
         finished_wall_clock = time.monotonic()
         finished_loop_clock = self.loop.time()
         self.assertLess(

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -462,6 +462,12 @@ class Test_ClockedTestCase(asynctest.ClockedTestCase):
             finished_wall_clock - started_wall_clock,
             finished_loop_clock - started_loop_clock)
 
+    @asyncio.coroutine
+    def test_negative_advance(self):
+        with self.assertRaisesRegex(ValueError, 'back in time'):
+            yield from self.advance(-1)
+        self.assertEqual(self.loop.time(), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Useful for testing stuff with timers.

Same sort of idea as Clock in twisted.trial if you're familiar with that.