### PR TITLE
Attempt to use 34selector when selector import fails

### DIFF
--- a/asynctest/selector.py
+++ b/asynctest/selector.py
@@ -11,7 +11,11 @@ can simulate the behavior of a selector on the mock objects, or forward actual
 work to a real selector.
 """
 
-import selectors
+try:
+    import selectors
+except ImportError:
+    import selectors34 as selectors
+
 import socket
 import ssl
 


### PR DESCRIPTION
For Python 3.x versions before selectors was made part of standard library, use the selectors34 library if the selectors import fails.