### PR TITLE
Complete support of scoped patchings for generators and coroutines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,8 @@ Mock and CoroutineMock
   - patch(), patch.object(), patch.multiple() return a MagickMock or
     CoroutineMock object by default, according to the patched target,
 
-  - patch(), patch.object(), patch.multiple() handle generators and coroutines,
+  - patch(), patch.object(), patch.multiple() handle generators and coroutines
+    and their behavior can be controled when the generator or coroutine pauses,
 
   - all the patch() methods can decorate coroutine functions,
 

--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -356,13 +356,13 @@ class ClockedTestCase(TestCase):
         Fast forward time by a number of ``seconds``.
 
         Callbacks scheduled to run up to the destination clock time will be
-        executed on time::
+        executed on time:
 
         >>> self.loop.call_later(1, print_time)
         >>> self.loop.call_later(2, self.loop.call_later, 1, print_time)
         >>> await self.advance(3)
-        ... 1
-        ... 3
+        1
+        3
 
         In this example, the third callback is scheduled at ``t = 2`` to be
         executed at ``t + 1``. Hence, it will run at ``t = 3``. The callback as

--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -572,6 +572,16 @@ def _patch_multiple(target, spec=None, create=False, spec_set=None,
 
 
 class _patch_dict(unittest.mock._patch_dict):
+    def decorate_class(self, klass):
+        for attr in dir(klass):
+            attr_value = getattr(klass, attr)
+            if (attr.startswith(patch.TEST_PREFIX) and
+                    hasattr(attr_value, "__call__")):
+                decorator = _patch_dict(self.in_dict, self.values, self.clear)
+                decorated = decorator(attr_value)
+                setattr(klass, attr, decorated)
+        return klass
+
     def __call__(self, f):
         if not asyncio.iscoroutinefunction(f):
             return super().__call__(f)

--- a/asynctest/selector.py
+++ b/asynctest/selector.py
@@ -177,10 +177,9 @@ def set_write_ready(fileobj, loop):
     data can be written to ``fileobj``.
 
     :param fileobj: file obkect or  :class:`~asynctest.FileMock` on which th
-    event is mocked.
-
+        event is mocked.
     :param loop: :class:`asyncio.SelectorEventLoop` watching for events on
-    ``fileobj``.
+        ``fileobj``.
 
     .. versionadded:: 0.4
     """

--- a/doc/asynctest.mock.rst
+++ b/doc/asynctest.mock.rst
@@ -25,11 +25,15 @@
     Patch
     ~~~~~
 
+    .. autodata:: asynctest.GLOBAL
+
+    .. autodata:: asynctest.LIMITED
+
     .. autofunction:: asynctest.patch
 
     .. function:: asynctest.patch.object(target, attribute, new=DEFAULT, \
                     spec=None, create=False, spec_set=None, autospec=None, \
-                    new_callable=None, **kwargs)
+                    new_callable=None, scope=asynctest.GLOBAL, **kwargs)
 
         Patch the named member (``attribute``) on an object (``target``) with
         a mock object, in the same fashion as :func:`~asynctest.patch`.
@@ -37,7 +41,8 @@
         See :func:`~asynctest.patch` and :func:`unittest.mock.patch.object`.
 
     .. function:: asynctest.patch.mutiple(target, spec=None, create=False, \
-                    spec_set=None, autospec=None, new_callable=None, **kwargs)
+                    spec_set=None, autospec=None, new_callable=None, \
+                    scope=asynctest.global, **kwargs)
 
         Perform multiple patches in a single call. It takes the object to be
         patched (either as an object or a string to fetch the object by
@@ -45,10 +50,17 @@
 
         See :func:`~asynctest.patch` and :func:`unittest.mock.patch.multiple`.
 
-    .. function:: asynctest.patch.dict(in_dict, values=(), clear=False, **kwargs)
+    .. function:: asynctest.patch.dict(in_dict, values=(), clear=False, \
+                    scope=asynctest.GLOBAL, **kwargs)
 
         Patch a dictionary, or dictionary like object, and restore the
         dictionary to its original state after the test.
+
+        Its behavior can be controlled on decorated generators and coroutines with
+        ``scope``.
+
+        .. versionadded:: 0.8 patch into generators and coroutines with
+                        a decorator.
 
         :param in_dict: dictionary like object, or string referencing the
                         object to patch.
@@ -56,8 +68,11 @@
                        pairs to set in the dictionary.
         :param clear: if ``True``, in_dict will be cleared before the new
                       values are set.
+        :param scope: :const:`asynctest.GLOBAL` or :const:`asynctest.LIMITED`,
+            controls when the patch is activated on generators and coroutines
 
-        See :func:`unittest.mock.patch.dict`.
+        :see: :func:`patch` (details about ``scope``) and
+            :func:`unittest.mock.patch.dict`.
 
     Helpers
     ~~~~~~~

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -51,6 +51,10 @@ patch_second_is_patched = functools.partial(
     asynctest.mock.patch, 'test.test_mock.Test.second_is_patched',
     new=lambda self: True)
 
+patch_dict_is_patched = functools.partial(
+    asynctest.mock.patch.dict, 'test.test_mock.Test.a_dict',
+    values={"is_patched": True})
+
 
 def inject_class(obj):
     # Decorate _Test_* mixin classes so we can retrieve the mock class to test
@@ -503,10 +507,6 @@ class Test_patch_multiple(unittest.TestCase):
 
 class Test_patch_dict(unittest.TestCase):
     def test_patch_decorates_coroutine(self):
-        patch = functools.partial(asynctest.mock.patch.dict,
-                                  'test.test_mock.Test.a_dict',
-                                  is_patched=True)
-
         @asyncio.coroutine
         def a_coroutine():
             import test.test_mock
@@ -519,10 +519,10 @@ class Test_patch_dict(unittest.TestCase):
 
         for coroutine in coroutines:
             with self.subTest(coroutine=coroutine):
-                self.assertTrue(run_coroutine(patch()(coroutine)()))
+                self.assertTrue(run_coroutine(patch_dict_is_patched()(coroutine)()))
 
     def test_patch_decorates_function(self):
-        @asynctest.mock.patch.dict('test.test_mock.Test.a_dict', is_patched=True)
+        @patch_dict_is_patched()
         def a_function():
             import test.test_mock
             return test.test_mock.Test().a_dict['is_patched']
@@ -530,7 +530,7 @@ class Test_patch_dict(unittest.TestCase):
         self.assertTrue(a_function())
 
     def test_patch_decorates_class(self):
-        @asynctest.mock.patch.dict('test.test_mock.Test.a_dict', is_patched=True)
+        @patch_dict_is_patched()
         class Patched:
             @asyncio.coroutine
             def test_a_coroutine(self):

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -407,6 +407,19 @@ class Test_patch_decorator_coroutine_or_generator(unittest.TestCase):
             a_new_style_coroutine = patch_is_patched()(a_new_style_coroutine)
             run_coroutine(tester(a_new_style_coroutine))
 
+    def test_patched_coroutine_with_mock_args(self):
+        @asynctest.mock.patch('test.test_mock.Test', side_effect=lambda: None)
+        @asyncio.coroutine
+        def a_coroutine(mock):
+            loop = asyncio.get_event_loop()
+            self.assertIs(mock, Test)
+            yield from asyncio.sleep(0, loop=loop)
+            self.assertIs(mock, Test)
+            yield from asyncio.sleep(0, loop=loop)
+            self.assertIs(mock, Test)
+
+        run_coroutine(a_coroutine())
+
     def test_generator_arg_is_default_mock(self):
         @asynctest.mock.patch('test.test_mock.Test')
         def a_generator(mock):

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -529,6 +529,22 @@ class Test_patch_dict(unittest.TestCase):
 
         self.assertTrue(a_function())
 
+    def test_patch_decorates_class(self):
+        @asynctest.mock.patch.dict('test.test_mock.Test.a_dict', is_patched=True)
+        class Patched:
+            @asyncio.coroutine
+            def test_a_coroutine(self):
+                import test.test_mock
+                return test.test_mock.Test().a_dict['is_patched']
+
+            def test_a_function(self):
+                import test.test_mock
+                return test.test_mock.Test().a_dict['is_patched']
+
+        instance = Patched()
+        self.assertTrue(instance.test_a_function())
+        self.assertTrue(run_coroutine(instance.test_a_coroutine()))
+
 
 #
 # patch scopes


### PR DESCRIPTION
asynctest 0.7 introduced the limited scope of the patches for generators and coroutines, but most of the time, patches are used on test methods, and keeping the patch activated as long as the coroutine is running makes more sense.

By default, scope is set to GLOBAL, but can be set to LIMITED to deactivate the patch when the coroutine is paused.

It also works with patch.dict, and (should) work with patch.multiple and patch.object as they are only other interfaces to patch.