### PR TITLE
Add a @fail_on decorator instead of @ignore_loop

### DIFF
--- a/asynctest/__init__.py
+++ b/asynctest/__init__.py
@@ -23,6 +23,7 @@ from .case import *
 from .mock import *
 
 # And load or own tools
+from ._fail_on import *
 from .helpers import *
 from .selector import *
 

--- a/asynctest/_fail_on.py
+++ b/asynctest/_fail_on.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+"""
+:class:`asynctest.TestCase` decorator which controls checks performed after
+tests.
+
+This module is separated from :mod:`asynctest.case` to avoid circular imports
+in modules registering new checks.
+"""
+
+
+_FAIL_ON_ATTR = "_asynctest_fail_on"
+
+
+DEFAULTS = {
+    "unused_loop": True,
+}
+
+
+class _fail_on:
+    def __init__(self, checks=None):
+        self.checks = checks or {}
+
+    def __call__(self, func):
+        checker = getattr(func, _FAIL_ON_ATTR, None)
+        if checker:
+            checker = checker.copy()
+            checker.update(self.checks)
+        else:
+            checker = self.copy()
+
+        setattr(func, _FAIL_ON_ATTR, checker)
+        return func
+
+    def update(self, checks, override=True):
+        if override:
+            self.checks.update(checks)
+        else:
+            for check, value in checks.items():
+                self.checks.setdefault(check, value)
+
+    def copy(self):
+        return _fail_on(self.checks.copy())
+
+    def get_checks(self, case):
+        checks = DEFAULTS.copy()
+
+        try:
+            checks.update(getattr(case, _FAIL_ON_ATTR, None).checks)
+        except AttributeError:
+            pass
+
+        checks.update(self.checks)
+
+        return checks
+
+    def check_test(self, case):
+        checks = self.get_checks(case)
+        for check in filter(checks.get, checks):
+            getattr(self, check)(case)
+
+    # checks
+
+    @staticmethod
+    def unused_loop(case):
+        if not case.loop._asynctest_ran:
+            case.fail("Loop did not run during the test")
+
+
+def fail_on(**kwargs):
+    """
+    Enable checks on the loop state after a test ran to help testers to
+    identify common mistakes.
+    """
+    # documented in asynctest.case.rst
+    for kwarg in kwargs:
+        if kwarg not in DEFAULTS:
+            raise TypeError("fail_on() got an unexpected keyword argument "
+                            "'{}'".format(kwarg))
+
+    return _fail_on(kwargs)
+
+
+def _fail_on_all(flag, func):
+    checker = _fail_on(dict((arg, flag) for arg in DEFAULTS))
+    return checker if func is None else checker(func)
+
+
+def strict(func=None):
+    """
+    Activate strict checking of the state of the loop after a test ran.
+    """
+    # documented in asynctest.case.rst
+    return _fail_on_all(True, func)
+
+
+def lenient(func=None):
+    """
+    Deactivate all checks after a test ran.
+    """
+    # documented in asynctest.case.rst
+    return _fail_on_all(False, func)

--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -484,10 +484,22 @@ def fail_on(**kwargs):
     return _fail_on(kwargs)
 
 
+def _fail_on_all(flag, func):
+    checker = _fail_on(dict((arg, flag) for arg in FAIL_ON_DEFAULTS))
+    return checker if func is None else checker(func)
+
+
 def strict(func=None):
     """
     Activate strict checking of the state of the loop after a test ran.
     """
     # documented in asynctest.case.rst
-    checker = _fail_on(dict((arg, True) for arg in FAIL_ON_DEFAULTS))
-    return checker if func is None else checker(func)
+    return _fail_on_all(True, func)
+
+
+def lenient(func=None):
+    """
+    Deactivate all checks after a test ran.
+    """
+    # documented in asynctest.case.rst
+    return _fail_on_all(False, func)

--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -698,7 +698,7 @@ patch.object = _patch_object
 patch.dict = _patch_dict
 patch.multiple = _patch_multiple
 patch.stopall = unittest.mock._patch_stopall
-patch.TEST_PREFIX = unittest.mock.patch.TEST_PREFIX
+patch.TEST_PREFIX = 'test'
 
 
 sentinel = unittest.mock.sentinel

--- a/doc/asynctest.case.rst
+++ b/doc/asynctest.case.rst
@@ -36,9 +36,54 @@
 
     Decorators
     ~~~~~~~~~~
+    .. decorator:: asynctest.fail_on(**checks)
+
+        Enable checks on the loop state after a test ran to help testers to
+        identify common mistakes.
+
+        Enable or disable a check using a keywork argument with a boolean
+        value::
+
+            @asynctest.fail_on(unused_loop=False)
+            class TestCase(asynctest.TestCase):
+                ...
+
+        Available checks are:
+
+            * ``unused_loop``: enabled by default, checks that the loop ran at
+              least once during the test. This check can not fail if the test
+              method is a coroutine. This allows to detect cases where a test
+              author assume its test will run tasks or callbacks on the loop,
+              but it actually didn't.
+
+        The decorator of a method has a greater priority than the decorator of
+        a class. When :func:`fail_on` decorates a class and one of its methods
+        with conflicting arguments, those of the class are overriden.
+
+        Subclasses of a decorated :class:`TestCase` inherit of the checks
+        enabled on the parent class.
+
+        .. versionadded:: 0.8
+
+    .. decorator:: strict
+
+        Activate strict checking of the state of the loop after a test ran.
+
+        It is a shortcut to :func:`fail_on` with all checks set to ``True``.
+
+        Note that by definition, the behavior of :func:`strict` will change in
+        the future when new checks will be added, and may break existing tests
+        with new errors after an update of the library.
+
+        .. versionadded:: 0.8
+
     .. decorator:: asynctest.ignore_loop
 
        By default, a test fails if the loop did not run during the test
        (including set up and tear down), unless the
        :class:`~asynctest.TestCase` class or test function is decorated by
        :func:`~asynctest.ignore_loop`.
+
+        .. deprecated:: 0.8
+
+            Use :func:`fail_on` with ``unused_loop=False`` instead.

--- a/doc/asynctest.case.rst
+++ b/doc/asynctest.case.rst
@@ -57,11 +57,12 @@
               but it actually didn't.
 
         The decorator of a method has a greater priority than the decorator of
-        a class. When :func:`fail_on` decorates a class and one of its methods
-        with conflicting arguments, those of the class are overriden.
+        a class. When :func:`~asynctest.fail_on` decorates a class and one of
+        its methods with conflicting arguments, those of the class are
+        overriden.
 
-        Subclasses of a decorated :class:`TestCase` inherit of the checks
-        enabled on the parent class.
+        Subclasses of a decorated :class:`~asynctest.TestCase` inherit of the
+        checks enabled on the parent class.
 
         .. versionadded:: 0.8
 
@@ -69,7 +70,8 @@
 
         Activate strict checking of the state of the loop after a test ran.
 
-        It is a shortcut to :func:`fail_on` with all checks set to ``True``.
+        It is a shortcut to :func:`~asynctest.fail_on` with all checks set to
+        ``True``.
 
         Note that by definition, the behavior of :func:`strict` will change in
         the future when new checks will be added, and may break existing tests
@@ -81,7 +83,8 @@
 
         Deactivate all checks performed after a test ran.
 
-        It is a shortcut to :func:`fail_on` with all checks set to ``False``.
+        It is a shortcut to :func:`~asynctest.fail_on` with all checks set to
+        ``False``.
 
         .. versionadded:: 0.8
 
@@ -94,4 +97,4 @@
 
         .. deprecated:: 0.8
 
-            Use :func:`fail_on` with ``unused_loop=False`` instead.
+            Use :func:`~asynctest.fail_on` with ``unused_loop=False`` instead.

--- a/doc/asynctest.case.rst
+++ b/doc/asynctest.case.rst
@@ -77,6 +77,14 @@
 
         .. versionadded:: 0.8
 
+    .. decorator:: lenient
+
+        Deactivate all checks performed after a test ran.
+
+        It is a shortcut to :func:`fail_on` with all checks set to ``False``.
+
+        .. versionadded:: 0.8
+
     .. decorator:: asynctest.ignore_loop
 
        By default, a test fails if the loop did not run during the test

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -587,10 +587,12 @@ class Test_fail_on(_TestCase):
     def test_default_checks(self):
         for method in self.run_methods:
             with self.subTest(method=method):
-                getattr(Test.FooTestCase(), method)()
+                case = Test.FooTestCase()
+                getattr(case, method)()
 
                 self.assert_checked("default")
                 self.assert_not_checked("optional")
+                self.mocks["default"].assert_called_with(case)
 
     def test_checks_on_decorated_class(self):
         @asynctest.fail_on(optional=True)
@@ -639,10 +641,12 @@ class Test_fail_on(_TestCase):
 
         for method in self.run_methods:
             with self.subTest(method=method):
-                getattr(Test.FooTestCase(), method)()
+                case = Test.FooTestCase()
+                getattr(case, method)()
 
-        self.assert_checked("default")
-        self.assertTrue(mock.called)
+                self.assert_checked("default")
+                self.assertTrue(mock.called)
+                mock.assert_called_with(case)
 
     def test_non_existing_before_test_wont_fail(self):
         # set something not callable for default, nothing for optional, the

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -542,6 +542,19 @@ class Test_fail_on_decorator(unittest.TestCase):
 
         self.assert_checks_equal(TestCase(), foo=True, bar=True)
 
+    def test_lenient_decorator(self):
+        @asynctest.lenient
+        class TestCase(asynctest.TestCase):
+            pass
+
+        self.assert_checks_equal(TestCase(), foo=False, bar=False)
+
+        @asynctest.lenient()
+        class TestCase(asynctest.TestCase):
+            pass
+
+        self.assert_checks_equal(TestCase(), foo=False, bar=False)
+
 
 fail_on_defaults = {"default": True, "optional": False}
 

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -427,7 +427,7 @@ class Test_ClockedTestCase(asynctest.ClockedTestCase):
         self.assertEqual(call_time, expected)
 
 
-@unittest.mock.patch.dict("asynctest.case.FAIL_ON_DEFAULTS",
+@unittest.mock.patch.dict("asynctest._fail_on.DEFAULTS",
                           values={"foo": False, "bar": True},
                           clear=True)
 class Test_fail_on_decorator(unittest.TestCase):
@@ -438,7 +438,7 @@ class Test_fail_on_decorator(unittest.TestCase):
             case = obj.__self__
 
         try:
-            return getattr(obj, asynctest.case._FAIL_ON_ATTR).get_checks(case)
+            return getattr(obj, asynctest._fail_on._FAIL_ON_ATTR).get_checks(case)
         except AttributeError:
             if fatal:
                 self.fail("{!r} not decorated".format(obj))
@@ -559,16 +559,16 @@ class Test_fail_on_decorator(unittest.TestCase):
 fail_on_defaults = {"default": True, "optional": False}
 
 
-@unittest.mock.patch.dict("asynctest.case.FAIL_ON_DEFAULTS",
+@unittest.mock.patch.dict("asynctest._fail_on.DEFAULTS",
                           values=fail_on_defaults, clear=True)
 class Test_fail_on(_TestCase):
     def setUp(self):
         self.mocks = {}
         for method in fail_on_defaults:
             mock = self.mocks[method] = unittest.mock.Mock()
-            setattr(asynctest.case._fail_on, method, mock)
+            setattr(asynctest._fail_on._fail_on, method, mock)
 
-        self.addCleanup(lambda: [delattr(asynctest.case._fail_on, method)
+        self.addCleanup(lambda: [delattr(asynctest._fail_on._fail_on, method)
                                  for method in fail_on_defaults])
 
     def tearDown(self):
@@ -626,8 +626,8 @@ class Test_fail_on(_TestCase):
 
 
 @unittest.mock.patch.dict(
-    "asynctest.case.FAIL_ON_DEFAULTS",
-    unused_loop=asynctest.case.FAIL_ON_DEFAULTS['unused_loop'], clear=True)
+    "asynctest._fail_on.DEFAULTS",
+    unused_loop=asynctest._fail_on.DEFAULTS['unused_loop'], clear=True)
 class Test_fail_on_unused_loop(_TestCase):
     def test_fails_when_loop_didnt_run(self):
         with self.assertRaisesRegex(AssertionError,


### PR DESCRIPTION
@fail_on is a decorator applicable to a ``TestCase`` class or a test method which allows to enable/disable post-test checks. For instance, by default, we check if the loop ran during the test (excluding setup). This check can be deactivated with ``@fail_on(unused_loop=False)``.

It allows to easily add new checks, for instance if event callbacks are still registered to a selector, or if scheduled callbacks are still pending (see #13).

I'm almost ready to merge, but I want to play with it a bit more to see if something is missing.