### PR TITLE
fail_on active selector callbacks (add_reader/writer)

### DIFF
--- a/doc/asynctest.case.rst
+++ b/doc/asynctest.case.rst
@@ -56,6 +56,12 @@
               author assume its test will run tasks or callbacks on the loop,
               but it actually didn't.
 
+            * ``active_selector_callbacks``: enabled by default, checks that
+              any registered reader or writer callback on a selector loop (with
+              ``add_reader()`` or ``add_writer()``) is later explicitly
+              unregistered  (with ``remove_reader()`` or ``remove_writer()``)
+              before the end of the test.
+
         The decorator of a method has a greater priority than the decorator of
         a class. When :func:`~asynctest.fail_on` decorates a class and one of
         its methods with conflicting arguments, those of the class are

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -77,7 +77,7 @@ class Test_TestCase(_TestCase):
     def test_init_and_close_loop_for_test(self):
         default_loop = self.create_default_loop()
 
-        @asynctest.fail_on(unused_loop=False)
+        @asynctest.lenient
         class LoopTest(asynctest.TestCase):
             failing = False
 
@@ -682,8 +682,8 @@ class Test_fail_on(_TestCase):
 
 
 @unittest.mock.patch.dict(
-    "asynctest._fail_on.DEFAULTS",
-    unused_loop=asynctest._fail_on.DEFAULTS['unused_loop'], clear=True)
+    "asynctest._fail_on.DEFAULTS", clear=True,
+    unused_loop=asynctest._fail_on.DEFAULTS['unused_loop'])
 class Test_fail_on_unused_loop(_TestCase):
     def test_fails_when_loop_didnt_run(self):
         with self.assertRaisesRegex(AssertionError,


### PR DESCRIPTION
This PR implements the "active_selector_callbacks" check to @fail_on and solves #3.