### PR TITLE
Fix specifying a setUp() method for ClockedTestCase

### DIFF
--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -350,8 +350,8 @@ class ClockedTestCase(TestCase):
     Subclass of :class:`~asynctest.TestCase` with a controlled loop clock,
     useful for testing timer based behaviour without slowing test run time.
     """
-    def setUp(self):
-        super().setUp()
+    def _init_loop(self):
+        super()._init_loop()
         self.loop.time = functools.wraps(self.loop.time)(lambda: self._time)
         self._time = 0
 

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -427,6 +427,26 @@ class Test_ClockedTestCase(asynctest.ClockedTestCase):
         self.assertEqual(call_time, expected)
 
 
+class Test_ClockedTestCase_setUp(asynctest.ClockedTestCase):
+    def setUp(self):
+        pass
+
+    @asyncio.coroutine
+    def test_setUp(self):
+        yield from self.advance(1)
+        self.assertEqual(1, self.loop.time())
+
+
+class Test_ClockedTestCase_async_setUp(asynctest.ClockedTestCase):
+    @asyncio.coroutine
+    def setUp(self):
+        yield from self.advance(1)
+
+    @asyncio.coroutine
+    def test_setUp(self):
+        self.assertEqual(1, self.loop.time())
+
+
 @unittest.mock.patch.dict("asynctest._fail_on.DEFAULTS",
                           values={"foo": False, "bar": True},
                           clear=True)


### PR DESCRIPTION
Here is a simple example that demonstrates the issue:

```python
class TestFoo(asynctest.ClockedTestCase):
    def setUp(self):
        print('Doing something')

    async def test_timeout(self):
        self.assertEqual(self._time, 0)
```

`TestFoo.setUp()` overrides `ClockedTestCase.setUp()`, so ClockedTestCase isn't initialized.

I solved the issue by renaming `ClockedTestCase.setUp()` to `_setUp()`, which is called by its parent's `run()` method.
