### PR TITLE
Stacktraces for exception are useless

### DIFF
--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -323,7 +323,11 @@ class TestCase(unittest.case.TestCase):
         # loop
         result = method()
         if asyncio.iscoroutine(result):
-            self.loop.run_until_complete(result)
+            @asyncio.coroutine
+            def wrapper():
+              try: yield from result
+              except BaseException as exc: raise
+            self.loop.run_until_complete(wrapper())
 
     def addCleanup(self, function, *args, **kwargs):
         """


### PR DESCRIPTION
Not entirely sure why, but without this patch, the stacktraces are absolutely useless:

Without the wrapper:
```
======================================================================
ERROR: test (test.books.ReadyWithoutContent)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/arthur/Documents/reaaad/redkeep/.venv/lib/python3.6/site-packages/asynctest/case.py", line 274, in run
    self._run_test_method(testMethod)
  File "/Users/arthur/Documents/reaaad/wyl/wyl/unittest.py", line 45, in _run_test_method
    self.loop.run_until_complete(result)
  File "/Users/arthur/Documents/reaaad/redkeep/.venv/lib/python3.6/site-packages/asynctest/case.py", line 200, in wrapper
    return method(*args, **kwargs)
  File "/usr/local/Cellar/python3/3.6.0b3_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/base_events.py", line 449, in run_until_complete
    return future.result()
AttributeError: 'NoneType' object has no attribute 'items'
```

With the wrapper:
```
======================================================================
ERROR: test (test.books.ReadyWithoutContent)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/arthur/Documents/reaaad/redkeep/.venv/lib/python3.6/site-packages/asynctest/case.py", line 274, in run
    self._run_test_method(testMethod)
  File "/Users/arthur/Documents/reaaad/wyl/wyl/unittest.py", line 44, in _run_test_method
    self.loop.run_until_complete(meth())
  File "/Users/arthur/Documents/reaaad/redkeep/.venv/lib/python3.6/site-packages/asynctest/case.py", line 200, in wrapper
    return method(*args, **kwargs)
  File "/usr/local/Cellar/python3/3.6.0b3_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/base_events.py", line 449, in run_until_complete
    return future.result()
  File "/Users/arthur/Documents/reaaad/wyl/wyl/unittest.py", line 41, in meth
    await result
  File "/Users/arthur/Documents/reaaad/redkeep/test/books.py", line 24, in test
    for k, v in self.expected.items():
AttributeError: 'NoneType' object has no attribute 'items'
```