### PR TITLE
Add support to async magic methods

### DIFF
--- a/asynctest/_awaitable.py
+++ b/asynctest/_awaitable.py
@@ -21,3 +21,21 @@ def make_native_coroutine(coroutine):
         return await coroutine(*args, **kwargs)
 
     return wrapper
+
+
+class AsyncIterator:
+    """
+    Wraps an iterator in an asynchronous iterator.
+    """
+    def __init__(self, iterator):
+        self.iterator = iterator
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.iterator)
+        except StopIteration:
+            pass
+        raise StopAsyncIteration

--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -321,6 +321,12 @@ class MagicMock(AsyncMagicMixin, unittest.mock.MagicMock,
     If you want to mock a coroutine function, use :class:`CoroutineMock`
     instead.
 
+    :class:`MagicMock` allows to mock ``__aenter__``, ``__aexit__``,
+    ``__aiter__`` and ``__anext__``.
+
+    You can not mock ``__await__``. If you want to mock an object implementing
+    __await__, :class:`CoroutineMock` will likely be sufficient.
+
     see :class:`~asynctest.Mock`.
     """
 

--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -23,6 +23,12 @@ import unittest.mock
 if sys.version_info >= (3, 5):
     from . import _awaitable
     _async_magics = ("aenter", "aexit", "aiter", "anext")
+
+    # We use unittest.mock.MagicProxy which works well, but it's not aware that
+    # we want __aexit__ to return a falsy value by default.
+    # We add the entry in unittest internal dict as it will not change the
+    # normal behavior of unittest.
+    unittest.mock._return_values["__aexit__"] = False
 else:
     _awaitable = None
     _async_magics = ()

--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -22,7 +22,7 @@ import unittest.mock
 
 if sys.version_info >= (3, 5):
     from . import _awaitable
-    _async_magics = ("aenter", "aexit", )
+    _async_magics = ("aenter", "aexit", "aiter", "anext")
 else:
     _awaitable = None
     _async_magics = ()

--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -301,6 +301,9 @@ class CoroutineMock(Mock):
         # object is a coroutine
         self._is_coroutine = _is_coroutine
 
+    def _get_child_mock(self, **kwargs):
+        return MagicMock(**kwargs)
+
     def _mock_call(_mock_self, *args, **kwargs):
         try:
             result = super()._mock_call(*args, **kwargs)

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -271,6 +271,10 @@ class Test_CoroutineMock(unittest.TestCase, _Test_called_coroutine):
         mock = asynctest.mock.CoroutineMock()
         self.assertTrue(asyncio.iscoroutinefunction(mock))
 
+    def test_called_CoroutineMock_returns_MagicMock(self):
+        mock = asynctest.mock.CoroutineMock()
+        self.assertIsInstance(run_coroutine(mock()), asynctest.mock.MagicMock)
+
 
 class TestMockInheritanceModel(unittest.TestCase):
     to_test = {

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -188,9 +188,13 @@ class _Test_Spec_Spec_Set_Returns_Coroutine_Mock:
                 self.assertIsInstance(mock.a_function, (asynctest.Mock, asynctest.MagicMock))
                 self.assertNotIsInstance(mock.a_function, asynctest.CoroutineMock)
                 self.assertIsInstance(mock.a_coroutine, asynctest.CoroutineMock)
+                mock.a_coroutine.return_value = "PROBE"
+                self.assertEqual("PROBE", run_coroutine(mock.a_coroutine()))
 
                 if _using_await:
                     self.assertIsInstance(mock.an_async_coroutine, asynctest.CoroutineMock)
+                    mock.an_async_coroutine.return_value = "PROBE"
+                    self.assertEqual("PROBE", run_coroutine(mock.an_async_coroutine()))
 
     # Ensure the name of the mock is correctly set, tests bug #49.
     def test_mock_has_correct_name(self, klass):

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -8,19 +8,12 @@ import sys
 
 import asynctest
 
+from .utils import run_coroutine
+
 if sys.version_info >= (3, 5):
     from . import test_mock_await as _using_await
 else:
     _using_await = None
-
-
-def run_coroutine(coroutine):
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        return loop.run_until_complete(coroutine)
-    finally:
-        loop.close()
 
 
 class Test:
@@ -236,6 +229,15 @@ class _Test_Future:
             loop.close()
 
 
+# Import mixins based on the support of async/await keywords
+if _using_await:
+    _Test_Mock_Of_Async_Magic_Methods = inject_class(
+        _using_await._Test_Mock_Of_Async_Magic_Methods)
+else:
+    class _Test_Mock_Of_Async_Magic_Methods:
+        pass
+
+
 class Test_NonCallabableMock(unittest.TestCase, _Test_subclass,
                              _Test_iscoroutinefunction,
                              _Test_is_coroutine_property,
@@ -248,7 +250,8 @@ class Test_NonCallableMagicMock(unittest.TestCase, _Test_subclass,
                                 _Test_iscoroutinefunction,
                                 _Test_is_coroutine_property,
                                 _Test_Spec_Spec_Set_Returns_Coroutine_Mock,
-                                _Test_Future):
+                                _Test_Future,
+                                _Test_Mock_Of_Async_Magic_Methods):
     class_to_test = 'NonCallableMagicMock'
 
 
@@ -260,7 +263,7 @@ class Test_Mock(unittest.TestCase, _Test_subclass,
 
 class Test_MagicMock(unittest.TestCase, _Test_subclass,
                      _Test_Spec_Spec_Set_Returns_Coroutine_Mock,
-                     _Test_Future):
+                     _Test_Future, _Test_Mock_Of_Async_Magic_Methods):
     class_to_test = 'MagicMock'
 
 

--- a/test/test_mock_await.py
+++ b/test/test_mock_await.py
@@ -118,6 +118,19 @@ class _Test_Mock_Of_Async_Magic_Methods:
         self.assertTrue(enter_called)
         self.assertTrue(exit_called)
 
+    def test_context_manager_raise_exception_by_default(self, klass):
+        class InContextManagerException(Exception):
+            pass
+
+        async def raise_in(context_manager):
+            async with context_manager:
+                raise InContextManagerException()
+
+        instance = self.WithAsyncContextManager()
+        mock_instance = asynctest.mock.MagicMock(instance)
+        with self.assertRaises(InContextManagerException):
+            run_coroutine(raise_in(mock_instance))
+
     class WithAsyncIterator:
         def __init__(self):
             self.iter_called = False

--- a/test/test_mock_await.py
+++ b/test/test_mock_await.py
@@ -1,4 +1,7 @@
 # coding: utf-8
+from .utils import run_coroutine
+
+import asynctest.mock
 
 
 # add a new-style coroutine to the Test class:
@@ -28,3 +31,46 @@ def build_simple_coroutine(before_func, after_func=None):
         return before, after
 
     return a_coroutine
+
+
+class _Test_Mock_Of_Async_Magic_Methods:
+    class WithAsyncContextManager:
+        def __init__(self):
+            self.entered = False
+            self.exited = False
+
+        async def __aenter__(self, *args, **kwargs):
+            self.entered = True
+            return self
+
+        async def __aexit__(self, *args, **kwargs):
+            self.exited = True
+
+    def test_mock_magic_methods_are_coroutine_mocks(self, klass):
+        instance = self.WithAsyncContextManager()
+        mock_instance = asynctest.mock.MagicMock(instance)
+        self.assertIsInstance(mock_instance.__aenter__,
+                              asynctest.mock.CoroutineMock)
+        self.assertIsInstance(mock_instance.__aexit__,
+                              asynctest.mock.CoroutineMock)
+
+    def test_mock_supports_async_context_manager(self, klass):
+        called = False
+        instance = self.WithAsyncContextManager()
+        mock_instance = asynctest.mock.MagicMock(instance)
+
+        async def use_context_manager():
+            nonlocal called
+            async with mock_instance as result:
+                called = True
+
+            return result
+
+        result = run_coroutine(use_context_manager())
+        self.assertFalse(instance.entered)
+        self.assertFalse(instance.exited)
+        self.assertTrue(called)
+        self.assertTrue(mock_instance.__aenter__.called)
+        self.assertTrue(mock_instance.__aexit__.called)
+        self.assertIsNot(mock_instance, result)
+        self.assertIsInstance(result, asynctest.mock.MagicMock)

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+import asyncio
+
+
+def run_coroutine(coroutine):
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        return loop.run_until_complete(coroutine)
+    finally:
+        loop.close()


### PR DESCRIPTION
This pull request adds the support of asynchronous context managers and asynchronous iterators.

This is still a WIP:

> I implemented aenter, aexit, aiter and anext.
>
> I think there are cases left to test, especially cases dealing with exceptions (eg: when an exception is raised inside an asynchronous context manager, the exception seems to be swallowed and lost).
>
> It's also tedious to mock those magic methods, because the async context manager class must be used as mock spec. Classes like AsyncContextManagerMock and AsyncIteratorMock can be useful to provide a more user friendly API.