### PR TITLE
Add PYPI deploy to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
 - 3.4
 - 3.5
-- 3.6
+- &python_major_ver 3.6
 - nightly
 script:
 - python -m unittest test
@@ -12,3 +12,26 @@ env:
   matrix:
   - ""
   - PYTHONASYNCIODEBUG=1
+
+jobs:
+  fast_finish: true
+
+  include:
+  - stage: &deploy_stage_name deploy to PYPI
+    python: *python_major_ver
+    script: skip
+    deploy: &deploy_step
+      provider: pypi
+      distribution: sdist bdist_wheel
+      user: martius
+      password:
+        secure: CkgSH/6923CeZK+4ZW9Flm/az4ne7ODxhdEPWfk/NCU6pBAQNw1mCCE71kCKk8jPZ+R/1yHXR1uoXSblDmE4vNMJoHVg3NxEFZ7HZC82ZRmqSDxIMzUw+mVyvvNE6qrKXtSAOF7un8YpMrKCN60/zdOap4lcmTkrq/5R/tVH7bQ=
+      on: # Only when a tag is on master and matches vX.Y.Z
+        tags: true
+        branch: master
+        condition: '$TRAVIS_TAG =~ ^v([0-9]+\.){2}[0-9]+$'
+
+stages:
+- test
+- name: *deploy_stage_name
+  if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
-    - "3.4"
-    - "3.5"
-    - "3.6"
-    - "nightly"
-install:
+- 3.4
+- 3.5
+- 3.6
+- nightly
 script:
-    - python -m unittest test
-    - PYTHONASYNCIODEBUG=1 python -m unittest test
+- python -m unittest test
+- PYTHONASYNCIODEBUG=1 python -m unittest test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+cache: pip
 language: python
 python:
 - 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,8 @@ python:
 - nightly
 script:
 - python -m unittest test
-- PYTHONASYNCIODEBUG=1 python -m unittest test
+
+env:
+  matrix:
+  - ""
+  - PYTHONASYNCIODEBUG=1


### PR DESCRIPTION
Also:
* simplified test jobs and converted to matrix
* simplified bits of yaml

Action items:
* encrypt your password and replace placeholder via additional commit to this branch

Refs:
- #50
- https://docs.travis-ci.com/user/encryption-keys/
- https://github.com/blog/2247-improving-collaboration-with-forks

Bonus possibilities:
- it is possible to store version with git tags and include it into distribution automatically via [setuptools-scm](https://pypi.python.org/pypi/setuptools_scm), but I didn't add this since I don't know whether you want it. It's just one line of code in `setup.py` anyway :)