### PR TITLE
Ensure shutdown_asyncgens is called for Python 3.6+.

### DIFF
--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -46,6 +46,7 @@ import asyncio
 import functools
 import types
 import unittest.case
+import sys
 import warnings
 
 from unittest.case import *  # NOQA
@@ -201,6 +202,8 @@ class TestCase(unittest.case.TestCase):
         policy = asyncio.get_event_loop_policy()
 
         if not self.use_default_loop:
+            if sys.version_info >= (3, 6):
+                self.loop.run_until_complete(self.loop.shutdown_asyncgens())
             self.loop.close()
             policy.reset_watcher()
 

--- a/test/test_case.py
+++ b/test/test_case.py
@@ -107,6 +107,10 @@ class Test_TestCase(_TestCase):
 
                 mock.assert_called_with()
                 mock_loop.close.assert_called_with()
+
+                if sys.version_info >= (3, 6):
+                    mock_loop.run_until_complete.__wrapped__.assert_called_with(mock_loop.shutdown_asyncgens())
+
                 self.assertFalse(case.failing)
                 self.assertIs(default_loop, asyncio.get_event_loop())
 


### PR DESCRIPTION
See [PEP 525](https://www.python.org/dev/peps/pep-0525/#asyncio)

This is a backport from @GreatFruitOmsk's internal `async_unittest` written by @amezin.