### PR TITLE
Deactivate unused_loop check by default

### DIFF
--- a/asynctest/_fail_on.py
+++ b/asynctest/_fail_on.py
@@ -30,7 +30,7 @@ _FAIL_ON_ATTR = "_asynctest_fail_on"
 #: the name of the static method performing the check in the :class:`_fail_on`.
 #: The value is True when the check is enabled by default, False otherwise.
 DEFAULTS = {
-    "unused_loop": True,
+    "unused_loop": False,
     "active_handles": False,
 }
 

--- a/doc/asynctest.case.rst
+++ b/doc/asynctest.case.rst
@@ -44,13 +44,13 @@
         Enable or disable a check using a keywork argument with a boolean
         value::
 
-            @asynctest.fail_on(unused_loop=False)
+            @asynctest.fail_on(unused_loop=True)
             class TestCase(asynctest.TestCase):
                 ...
 
         Available checks are:
 
-            * ``unused_loop``: enabled by default, checks that the loop ran at
+            * ``unused_loop``: disabled by default, checks that the loop ran at
               least once during the test. This check can not fail if the test
               method is a coroutine. This allows to detect cases where a test
               author assume its test will run tasks or callbacks on the loop,
@@ -79,7 +79,14 @@
         .. versionadded:: 0.8
 
         .. versionadded:: 0.9
-            ``active_handles``
+           ``active_handles``
+
+        .. versionadded:: 0.12
+           ``unused_loop`` is now deactivated by default to maintain
+           compatibility with non-async test inherited from
+           :class:`unittest.TestCase`. This check is especially useful to track
+           missing ``@asyncio.coroutine`` decorators in a codebase that must be
+           compatbible with Python 3.4.
 
     .. decorator:: strict
 


### PR DESCRIPTION
Following the discussion in bug #63, we can assume that most of our
users will target Python 3.5+ and most code bases will rely on the
"async" keyword to declare coroutines.

This check is only useful when tracking missing @asyncio.coroutine in
"legacy" code bases, while breaking inherited normal "test cases" if
enabled by default.