### PR TITLE
make @patch with create_autospec mock coroutines correctly

### DIFF
--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -908,6 +908,34 @@ class Test_patch_dict(unittest.TestCase):
         self.assertFalse(test.test_mock.Test().a_dict['is_patched'])
 
 
+class Test_patch_autospec(unittest.TestCase):
+    def test_autospec_coroutine(self):
+        test_class_path = "{}.Test".format(__name__)
+        called = False
+
+        @asynctest.mock.patch(test_class_path, autospec=True)
+        def patched(mock):
+            nonlocal called
+            called = True
+            self.assertIsInstance(mock.a_coroutine,
+                                  asynctest.mock.CoroutineMock)
+
+            self.assertIsInstance(mock().a_coroutine,
+                                  asynctest.mock.CoroutineMock)
+
+            self.assertIsInstance(mock.a_function, asynctest.mock.Mock)
+            self.assertIsInstance(mock().a_function, asynctest.mock.Mock)
+
+            if _using_await:
+                self.assertIsInstance(mock.an_async_coroutine,
+                                      asynctest.mock.CoroutineMock)
+                self.assertIsInstance(mock().an_async_coroutine,
+                                      asynctest.mock.CoroutineMock)
+
+        patched()
+        self.assertTrue(called)
+
+
 #
 # patch scopes
 #


### PR DESCRIPTION
We need to override asynctest.mock.patch to ensure it uses our version of create_autospec, which supports coroutines (fix of #46).

I'm not yet sure everything works as expected so I'll probably review it and add some tests later (for patch.object, patch.dict, etc).