### PR TITLE
Fix tests for PyPy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,8 @@ classifiers =
    Programming Language :: Python :: 3.4
    Programming Language :: Python :: 3.5
    Programming Language :: Python :: 3.6
+   Programming Language :: Python :: Implementation :: CPython
+   Programming Language :: Python :: Implementation :: PyPy
 license = Apache 2
 license_file = LICENSE.md
 description = Enhance the standard unittest package with features for testing asyncio libraries


### PR DESCRIPTION
Some tests relied on CPython's garbage collection behavior
where objects are deleted (by calling the corresponding __del__)
immediately when their scope ends.

PyPy is different by design. The workaround is
to close object explicitly.