### PR TITLE
Fix patch.dict() (updated in python 3.7) #115

### DIFF
--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -1247,6 +1247,11 @@ class _patch_dict(unittest.mock._patch_dict):
     def _patch_dict(self):
         self._is_started = True
 
+        # Since Python 3.7.3, the moment when a dict specified by a target
+        # string has been corrected. (see #115)
+        if isinstance(self.in_dict, str):
+            self.in_dict = unittest.mock._importer(self.in_dict)
+
         try:
             self._original = self.in_dict.copy()
         except AttributeError:


### PR DESCRIPTION
This patch can not be merged unless it works with all versions of Python we support.

The bug that bpo-25512 fixes is not fixed in older releases, but asynctest works as expected (ie: it still works as unittest.mock.patch.dict).