### PR TITLE
Support __getattr__, __setattr__ and __delatrr__ for async magic methods

### DIFF
--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -52,6 +52,7 @@ if sys.version_info >= (3, 5):
         return __aiter__
 
     unittest.mock._side_effect_methods["__aiter__"] = _get_async_iter
+    unittest.mock._all_magics |= _async_magics
 else:
     _awaitable = None
     async_magic_coroutines = _async_magics = set()
@@ -130,6 +131,8 @@ def _set_is_coroutine(self, value):
     self.__dict__['_mock_is_coroutine'] = value
 
 
+# _mock_add_spec() is the actual private implementation in unittest.mock, we
+# override it to support coroutines in the metaclass.
 def _mock_add_spec(self, spec, *args, **kwargs):
     unittest.mock.NonCallableMock._mock_add_spec(self, spec, *args, **kwargs)
 

--- a/asynctest/mock.py
+++ b/asynctest/mock.py
@@ -194,11 +194,12 @@ class IsCoroutineArgMeta(MockMetaMixin):
                 '_is_coroutine': property(_get_is_coroutine),
             })
 
-            def __setattr__(self, name, value):
-                if name == 'is_coroutine':
+            wrapped_setattr = namespace.get("__setattr__", base[0].__setattr__)
+            def __setattr__(self, attrname, value):
+                if attrname == 'is_coroutine':
                     self._asynctest_set_is_coroutine(value)
                 else:
-                    return base[0].__setattr__(self, name, value)
+                    return wrapped_setattr(self, attrname, value)
 
             namespace['__setattr__'] = __setattr__
 

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -2016,5 +2016,27 @@ class Test_create_autospec(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             asynctest.mock.create_autospec(Test.a_coroutine, instance=True)
 
+    if _using_await:
+        def test_mock_add_spec_on_mock_created_with_autospec(self):
+            # See bug #107
+            mock = asynctest.mock.create_autospec(Test())
+
+            self.assertFalse(hasattr(mock, "added_attribute"))
+            mock.mock_add_spec(["added_attribute"])
+            self.assertIsInstance(mock.added_attribute, asynctest.Mock)
+
+            self.assertFalse(hasattr(mock, "__aenter__"))
+            mock.mock_add_spec(["__aenter__"])
+            self.assertTrue(hasattr(mock, "__aenter__"))
+
+        def test_mock_add_spec_on_mock_with_magics(self):
+            instance =_using_await._Test_Mock_Of_Async_Magic_Methods.WithAsyncContextManager()
+            mock = asynctest.mock.create_autospec(instance)
+
+            self.assertFalse(hasattr(mock, "added_attribute"))
+            mock.mock_add_spec(["added_attribute"])
+            self.assertIsInstance(mock.added_attribute, asynctest.Mock)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This ensures that async magic methods are correctly handled by mocks in the get/set/del attrs magics.

I tested a bunch of things but I think it's not worse trying to override the original magics again, just changing unittest.mock._all_magics is sufficient (even if it will change the behavior of unittest).

I added an unrelated fix which showed a bug when overriding ``NonCallableMock.__setattr__()``.