### PR TITLE
Keep a view on internal selector map in TestSelector

### DIFF
--- a/asynctest/selector.py
+++ b/asynctest/selector.py
@@ -12,6 +12,7 @@ work to a real selector.
 """
 
 import asyncio
+import collections
 try:
     import selectors
 except ImportError:
@@ -216,6 +217,8 @@ class TestSelector(selectors._BaseSelectorImpl):
     def __init__(self, selector=None):
         super().__init__()
         self._selector = selector
+        if selector is not None:
+            self._fd_to_key = collections.ChainMap({}, selector.get_map())
 
     def _fileobj_lookup(self, fileobj):
         if isfilemock(fileobj):
@@ -240,9 +243,6 @@ class TestSelector(selectors._BaseSelectorImpl):
         else:
             key = self._selector.register(fileobj, events, data)
 
-            if key:
-                self._fd_to_key[key.fd] = key
-
         return key
 
     def unregister(self, fileobj):
@@ -255,9 +255,6 @@ class TestSelector(selectors._BaseSelectorImpl):
             key = super().unregister(fileobj)
         else:
             key = self._selector.unregister(fileobj)
-
-            if key and key.fd in self._fd_to_key:
-                del self._fd_to_key[key.fd]
 
         return key
 
@@ -272,16 +269,7 @@ class TestSelector(selectors._BaseSelectorImpl):
         if isfilemock(fileobj) or self._selector is None:
             key = super().modify(fileobj, events, data)
         else:
-            # del the key first because modify() fails if events is incorrect
-            fd = self._fileobj_lookup(fileobj)
-
-            if fd in self._fd_to_key:
-                del self._fd_to_key[fd]
-
             key = self._selector.modify(fileobj, events, data)
-
-            if key:
-                self._fd_to_key[key.fd] = key
 
         return key
 


### PR DESCRIPTION
Change `TestSelector._fd_to_key` from a extended copy of `TestSelector._selector._fd_to_key` to a view on `TestSelector._selector._fd_to_key` plus the *test-part* extension. As a result, there is no need to update `TestSelector._fd_to_key` when `TestSelector._selector._fd_to_key` is modified.

fix #128