### PR TITLE
Bugfix/126 coroutine deprecated warnings

### DIFF
--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -353,8 +353,7 @@ class TestCase(unittest.TestCase):
         if asyncio.iscoroutine(result):
             self.loop.run_until_complete(result)
 
-    @asyncio.coroutine
-    def doCleanups(self):
+    async def doCleanups(self):
         """
         Execute all cleanup functions. Normally called for you after tearDown.
         """
@@ -363,7 +362,7 @@ class TestCase(unittest.TestCase):
             function, args, kwargs = self._cleanups.pop()
             with outcome.testPartExecutor(self):
                 if asyncio.iscoroutinefunction(function):
-                    yield from function(*args, **kwargs)
+                    await function(*args, **kwargs)
                 else:
                     function(*args, **kwargs)
 
@@ -377,8 +376,7 @@ class TestCase(unittest.TestCase):
         """
         return super().addCleanup(function, *args, **kwargs)
 
-    @asyncio.coroutine
-    def assertAsyncRaises(self, exception, awaitable):
+    async def assertAsyncRaises(self, exception, awaitable):
         """
         Test that an exception of type ``exception`` is raised when an
         exception is raised when awaiting ``awaitable``, a future or coroutine.
@@ -386,10 +384,9 @@ class TestCase(unittest.TestCase):
         :see: :meth:`unittest.TestCase.assertRaises()`
         """
         with self.assertRaises(exception):
-            return (yield from awaitable)
+            return await awaitable
 
-    @asyncio.coroutine
-    def assertAsyncRaisesRegex(self, exception, regex, awaitable):
+    async def assertAsyncRaisesRegex(self, exception, regex, awaitable):
         """
         Like :meth:`assertAsyncRaises()` but also tests that ``regex`` matches
         on the string representation of the raised exception.
@@ -397,10 +394,9 @@ class TestCase(unittest.TestCase):
         :see: :meth:`unittest.TestCase.assertRaisesRegex()`
         """
         with self.assertRaisesRegex(exception, regex):
-            return (yield from awaitable)
+            return await awaitable
 
-    @asyncio.coroutine
-    def assertAsyncWarns(self, warning, awaitable):
+    async def assertAsyncWarns(self, warning, awaitable):
         """
         Test that a warning is triggered when awaiting ``awaitable``, a future
         or a coroutine.
@@ -408,10 +404,9 @@ class TestCase(unittest.TestCase):
         :see: :meth:`unittest.TestCase.assertWarns()`
         """
         with self.assertWarns(warning):
-            return (yield from awaitable)
+            return await awaitable
 
-    @asyncio.coroutine
-    def assertAsyncWarnsRegex(self, warning, regex, awaitable):
+    async def assertAsyncWarnsRegex(self, warning, regex, awaitable):
         """
         Like :meth:`assertAsyncWarns()` but also tests that ``regex`` matches
         on the message of the triggered warning.
@@ -419,7 +414,7 @@ class TestCase(unittest.TestCase):
         :see: :meth:`unittest.TestCase.assertWarnsRegex()`
         """
         with self.assertWarnsRegex(warning, regex):
-            return (yield from awaitable)
+            return await awaitable
 
 
 class FunctionTestCase(TestCase, unittest.FunctionTestCase):
@@ -441,8 +436,7 @@ class ClockedTestCase(TestCase):
         self.loop.time = functools.wraps(self.loop.time)(lambda: self._time)
         self._time = 0
 
-    @asyncio.coroutine
-    def advance(self, seconds):
+    async def advance(self, seconds):
         """
         Fast forward time by a number of ``seconds``.
 
@@ -463,7 +457,7 @@ class ClockedTestCase(TestCase):
             raise ValueError(
                 'Cannot go back in time ({} seconds)'.format(seconds))
 
-        yield from self._drain_loop()
+        await self._drain_loop()
 
         target_time = self._time + seconds
         while True:
@@ -472,10 +466,10 @@ class ClockedTestCase(TestCase):
                 break
 
             self._time = next_time
-            yield from self._drain_loop()
+            await self._drain_loop()
 
         self._time = target_time
-        yield from self._drain_loop()
+        await self._drain_loop()
 
     def _next_scheduled(self):
         try:
@@ -483,15 +477,14 @@ class ClockedTestCase(TestCase):
         except IndexError:
             return None
 
-    @asyncio.coroutine
-    def _drain_loop(self):
+    async def _drain_loop(self):
         while True:
             next_time = self._next_scheduled()
             if not self.loop._ready and (next_time is None or
                                          next_time > self._time):
                 break
 
-            yield from asyncio.sleep(0)
+            await asyncio.sleep(0)
             self.loop._TestCase_asynctest_ran = True
 
 

--- a/asynctest/helpers.py
+++ b/asynctest/helpers.py
@@ -9,8 +9,7 @@ Helper functions and coroutines for :mod:`asynctest`.
 import asyncio
 
 
-@asyncio.coroutine
-def exhaust_callbacks(loop):
+async def exhaust_callbacks(loop):
     """
     Run the loop until all ready callbacks are executed.
 
@@ -21,4 +20,4 @@ def exhaust_callbacks(loop):
     :param loop: event loop
     """
     while loop._ready:
-        yield from asyncio.sleep(0, loop=loop)
+        await asyncio.sleep(0, loop=loop)


### PR DESCRIPTION
Addresses 126
Addresses 132
---
This change removes the usages of `@asyncio.coroutine` and replaces them with the recommended `async def` functions instead. This is because as of Python3.8 which is now in Beta at the time of writing, using `@asyncio.coroutine` results in a deprecation warning.
---

This leaves two errors currently, both of which I am struggling to track down the source of, as they appear to have occurred when the file was loaded. One of which already existed from where I forked from.

```
$ python -m unittest --locals 
EE
======================================================================
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/lib/python3.7/unittest/__main__.py", line 18, in <module>
    main(module=None)
  File "/usr/lib/python3.7/unittest/main.py", line 101, in __init__
    self.runTests()
  File "/usr/lib/python3.7/unittest/main.py", line 271, in runTests
    self.result = testRunner.run(self.test)
  File "/usr/lib/python3.7/unittest/runner.py", line 183, in run
    result.printErrors()
  File "/usr/lib/python3.7/unittest/runner.py", line 109, in printErrors
    self.printErrorList('ERROR', self.errors)
  File "/usr/lib/python3.7/unittest/runner.py", line 115, in printErrorList
    self.stream.writeln("%s: %s" % (flavour,self.getDescription(test)))
  File "/usr/lib/python3.7/unittest/runner.py", line 47, in getDescription
    return '\n'.join((str(test), doc_first_line))
  File "/usr/lib/python3.7/unittest/case.py", line 1400, in __str__
    self._testFunc.__name__)
AttributeError: 'str' object has no attribute '__name__'
$ _
```
if you have any ideas on what is causing these, I will be happy to address them in this PR if desired.

Thanks

N.K.
