### PR TITLE
Support async tests which use Hypothesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 doc/_build
 virtualenv/
 venv*/
+.hypothesis/

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ matrix:
 
 install:
 - curl https://bootstrap.pypa.io/get-pip.py | python
-- python -m pip install --upgrade wheel>=0.30.0 setuptools>=36.6.0
+- python -m pip install --upgrade wheel>=0.30.0 setuptools>=36.6.0 hypothesis>=3.64
 
 script:
 - python -m unittest --verbose test

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Pyotr Ermishkin <quasiyoke@gmail.com>
 Random User <rndusr@posteo.de>
 Rémi Cardona <remi.cardona@polyconseil.fr>
 Sviatoslav Sydorenko <wk@sydorenko.org.ua>
+Stefan Tjarks <stefan@tjarks.de>

--- a/test/test_hypothesis_integration.py
+++ b/test/test_hypothesis_integration.py
@@ -1,0 +1,15 @@
+"""Tests for the Hypothesis integration, which wraps async functions in a
+sync shim for Hypothesis.
+"""
+
+import asynctest
+
+from hypothesis import given, strategies as st
+
+
+class TestHypothesisIntegration(asynctest.TestCase):
+
+    @given(st.integers())
+    async def test_mark_inner(self, n):
+        assert isinstance(n, int)
+


### PR DESCRIPTION
Work is heavily inspired by [pytest-asyncio](https://github.com/pytest-dev/pytest-asyncio/commit/d4c1b924c2e49a635893880cbb6745d8871a58b1)


Run into the issue that async tests decorated with hypothesis did not run. After digging into this a bit I found above commit in pytest-asyncio and [hypothesis](https://github.com/HypothesisWorks/hypothesis/pull/1343).