### PR TITLE
Add @final decorator to _setUp and _tearDown methods.

### DIFF
--- a/asynctest/case.py
+++ b/asynctest/case.py
@@ -49,6 +49,8 @@ import unittest
 import sys
 import warnings
 
+from typing import final
+
 from unittest.case import *  # NOQA
 
 import asynctest.selector
@@ -234,7 +236,8 @@ class TestCase(unittest.TestCase):
             loop._selector = asynctest.selector.TestSelector(loop._selector)
 
         return loop
-
+    
+    @final
     def _setUp(self):
         self._init_loop()
 
@@ -251,7 +254,8 @@ class TestCase(unittest.TestCase):
 
         # don't take into account if the loop ran during setUp
         self.loop._asynctest_ran = False
-
+    
+    @final
     def _tearDown(self):
         if asyncio.iscoroutinefunction(self.tearDown):
             self.loop.run_until_complete(self.tearDown())


### PR DESCRIPTION
They should not be overridden. 
I used _setUp in my own test and it took me a while to find the bug. So it would be good to set these to final.